### PR TITLE
Use tape, fix bug in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,38 +1,38 @@
 {
-    "name" : "binary",
-    "version" : "0.3.0",
-    "description" : "Unpack multibyte binary values from buffers",
-    "main" : "./index.js",
-    "repository" : {
-        "type" : "git",
-        "url" : "http://github.com/substack/node-binary.git"
-    },
-    "keywords": [
-        "binary",
-        "decode",
-        "endian",
-        "unpack",
-        "signed",
-        "unsigned"
-    ],
-    "author" : {
-        "name" : "James Halliday",
-        "email" : "mail@substack.net",
-        "url" : "http://substack.net"
-    },
-    "dependencies" : {
-        "chainsaw" : "~0.1.0",
-        "buffers" : "~0.1.1"
-    },
-    "devDependencies" : {
-        "seq" : "~0.2.5",
-        "tap" : "~0.2.4"
-    },
-    "scripts" : {
-        "test" : "tap test/*.js"
-    },
-    "license" : "MIT",
-    "engine" : {
-        "node" : ">=0.4.0"
-    }
+  "name": "binary",
+  "version": "0.3.0",
+  "description": "Unpack multibyte binary values from buffers",
+  "main": "./index.js",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/substack/node-binary.git"
+  },
+  "keywords": [
+    "binary",
+    "decode",
+    "endian",
+    "unpack",
+    "signed",
+    "unsigned"
+  ],
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "dependencies": {
+    "buffers": "~0.1.1",
+    "chainsaw": "~0.1.0"
+  },
+  "devDependencies": {
+    "seq": "~0.2.5",
+    "tap": "~0.2.4"
+  },
+  "scripts": {
+    "test": "tap test/*.js"
+  },
+  "license": "MIT",
+  "engine": {
+    "node": ">=0.4.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   },
   "devDependencies": {
     "seq": "~0.2.5",
-    "tap": "~0.2.4"
+    "tape": "^3.4.0"
   },
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "tape test/*.js"
   },
   "license": "MIT",
   "engine": {

--- a/test/bu.js
+++ b/test/bu.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('bu', function (t) {
     t.plan(8);

--- a/test/deferred.js
+++ b/test/deferred.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 var EventEmitter = require('events').EventEmitter;
 
 test('deferred', function (t) {

--- a/test/dots.js
+++ b/test/dots.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('dots', function (t) {
     t.plan(1);

--- a/test/eof.js
+++ b/test/eof.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 var EventEmitter = require('events').EventEmitter;
 
 test('eof', function (t) {

--- a/test/flush.js
+++ b/test/flush.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('flush', function (t) {
     t.plan(1);

--- a/test/from_buffer.js
+++ b/test/from_buffer.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('from buffer', function (t) {
     t.plan(1);

--- a/test/get_buffer.js
+++ b/test/get_buffer.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('get buffer', function (t) {
     t.plan(4);

--- a/test/immediate.js
+++ b/test/immediate.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 var EventEmitter = require('events').EventEmitter;
 
 test('immediate', function (t) {

--- a/test/interval.js
+++ b/test/interval.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 var EventEmitter = require('events').EventEmitter;
 
 test('interval', function (t) {

--- a/test/into_buffer.js
+++ b/test/into_buffer.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('intoBuffer', function (t) {
     t.plan(3);

--- a/test/into_stream.js
+++ b/test/into_stream.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 var EventEmitter = require('events').EventEmitter;
 
 test('into stream', function (t) {

--- a/test/loop.js
+++ b/test/loop.js
@@ -3,7 +3,7 @@ var test = require('tap').test;
 var EventEmitter = require('events').EventEmitter;
 
 test('loop', function (t) {
-    t.plan(3 * 2 + 1);
+    t.plan(4 * 2 + 1);
     
     var em = new EventEmitter;
     

--- a/test/loop.js
+++ b/test/loop.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 var EventEmitter = require('events').EventEmitter;
 
 test('loop', function (t) {

--- a/test/loop_scan.js
+++ b/test/loop_scan.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 var EventEmitter = require('events').EventEmitter;
 
 test('loop scan', function (t) {

--- a/test/lu.js
+++ b/test/lu.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('lu', function (t) {
     t.plan(8);

--- a/test/negbs.js
+++ b/test/negbs.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('negbs', function (t) {
     t.plan(4);

--- a/test/negls.js
+++ b/test/negls.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('negls', function (t) {
     t.plan(4);

--- a/test/nested.js
+++ b/test/nested.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 var EventEmitter = require('events').EventEmitter;
 
 test('nested', function (t) {

--- a/test/not_enough_buf.js
+++ b/test/not_enough_buf.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('not enough buf', function (t) {
     t.plan(3);

--- a/test/not_enough_parse.js
+++ b/test/not_enough_parse.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('not enough parse', function (t) {
     t.plan(4);

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('parse', function (t) {
     t.plan(6);

--- a/test/peek.js
+++ b/test/peek.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 var EventEmitter = require('events').EventEmitter;
 
 test('peek', function (t) {

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -3,7 +3,7 @@ var test = require('tap').test;
 var Stream = require('stream').Stream;
 
 test('loop', function (t) {
-    t.plan(3 * 2 + 1);
+    t.plan(4 * 2 + 1);
     
     var rs = new Stream;
     rs.readable = true;

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 var Stream = require('stream').Stream;
 
 test('loop', function (t) {

--- a/test/posbs.js
+++ b/test/posbs.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('posbs', function (t) {
     t.plan(4);

--- a/test/posls.js
+++ b/test/posls.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('posls', function (t) {
     t.plan(4);

--- a/test/scan.js
+++ b/test/scan.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 var EventEmitter = require('events').EventEmitter;
 
 test('scan', function (t) {

--- a/test/scan_buf.js
+++ b/test/scan_buf.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('scan buf', function (t) {
     t.plan(4);

--- a/test/scan_buf_null.js
+++ b/test/scan_buf_null.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 
 test('scan buf null', function (t) {
     t.plan(3);

--- a/test/skip.js
+++ b/test/skip.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 var EventEmitter = require('events').EventEmitter;
 var seq = require('seq');
 

--- a/test/split.js
+++ b/test/split.js
@@ -1,5 +1,5 @@
 var binary = require('../');
-var test = require('tap').test;
+var test = require('tape').test;
 var EventEmitter = require('events').EventEmitter;
 
 test('split', function (t) {


### PR DESCRIPTION
I wanted to run tests in the browser, so I switched to using tape.

Using tap also uncovered a bug in `t.plan()` calls, which have been fixed.